### PR TITLE
Add code to support second jogwheel instance

### DIFF
--- a/JogWheel.cpp
+++ b/JogWheel.cpp
@@ -16,11 +16,7 @@ JogWheel::JogWheel(const char position) {
         _opto2Pin = JOGWHEEL_RIGHT_OPTO2_PIN;
     }
 
-<<<<<<< HEAD
     // Initialize instance-level variables.
-=======
-    // Initialize member variables.
->>>>>>> ee8ceb4 (static stuff)
     _position1 = 0;
     _position2 = 0;
     _activePosition = &_position1;
@@ -33,11 +29,6 @@ void JogWheel::setup() {
   pinMode(_opto2Pin, INPUT);
   _lastState = (digitalRead(_opto1Pin) << 1) | digitalRead(_opto2Pin);
   
-<<<<<<< HEAD
-=======
-  // attachInterrupt(digitalPinToInterrupt(_opto1Pin), updatePosition, CHANGE);
-  // attachInterrupt(digitalPinToInterrupt(_opto2Pin), updatePosition, CHANGE);
->>>>>>> ee8ceb4 (static stuff)
   if (this == leftInstance) {
       attachInterrupt(digitalPinToInterrupt(_opto1Pin), handleLeftInterrupt, CHANGE);
       attachInterrupt(digitalPinToInterrupt(_opto2Pin), handleLeftInterrupt, CHANGE);

--- a/JogWheel.cpp
+++ b/JogWheel.cpp
@@ -16,7 +16,7 @@ JogWheel::JogWheel(const char position) {
         _opto2Pin = JOGWHEEL_RIGHT_OPTO2_PIN;
     }
 
-    // Initialize member variables.
+    // Initialize instance-level variables.
     _position1 = 0;
     _position2 = 0;
     _activePosition = &_position1;
@@ -29,8 +29,6 @@ void JogWheel::setup() {
   pinMode(_opto2Pin, INPUT);
   _lastState = (digitalRead(_opto1Pin) << 1) | digitalRead(_opto2Pin);
   
-  // attachInterrupt(digitalPinToInterrupt(_opto1Pin), updatePosition, CHANGE);
-  // attachInterrupt(digitalPinToInterrupt(_opto2Pin), updatePosition, CHANGE);
   if (this == leftInstance) {
       attachInterrupt(digitalPinToInterrupt(_opto1Pin), handleLeftInterrupt, CHANGE);
       attachInterrupt(digitalPinToInterrupt(_opto2Pin), handleLeftInterrupt, CHANGE);

--- a/JogWheel.cpp
+++ b/JogWheel.cpp
@@ -8,15 +8,22 @@ volatile int32_t* JogWheel::_activePosition = &_position1;
 volatile int32_t* JogWheel::_inactivePosition = &_position2;
 volatile int8_t JogWheel::_lastState = 0b00;
 
-JogWheel::JogWheel() {
+JogWheel::JogWheel(string position) {
+  if (position == "left") {
+    _opto1Pin = JOGWHEEL_LEFT_OPTO1_PIN;
+    _opto2Pin = JOGWHEEL_LEFT_OPTO2_PIN;
+  } else {
+    _opto1Pin = JOGWHEEL_RIGHT_OPTO1_PIN;
+    _opto2Pin = JOGWHEEL_RIGHT_OPTO2_PIN;
+  }
 }
 
 void JogWheel::setup() {
-  pinMode(JOGWHEEL_OPTO1_PIN, INPUT);
-  pinMode(JOGWHEEL_OPTO2_PIN, INPUT);
-  _lastState = (digitalRead(JOGWHEEL_OPTO1_PIN) << 1) | digitalRead(JOGWHEEL_OPTO2_PIN);
-  attachInterrupt(digitalPinToInterrupt(JOGWHEEL_OPTO1_PIN), JogWheel::updatePosition, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(JOGWHEEL_OPTO2_PIN), JogWheel::updatePosition, CHANGE);
+  pinMode(_opto1Pin, INPUT);
+  pinMode(_opto2Pin, INPUT);
+  _lastState = (digitalRead(_opto1Pin) << 1) | digitalRead(_opto2Pin);
+  attachInterrupt(digitalPinToInterrupt(_opto1Pin), JogWheel::updatePosition, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(_opto2Pin), JogWheel::updatePosition, CHANGE);
 }
 
 void JogWheel::CheckDataSendHID() {
@@ -37,7 +44,7 @@ void JogWheel::UpdateAnimationFrame() {
 }
 
 void JogWheel::updatePosition() {
-  int8_t newState = (digitalRead(JOGWHEEL_OPTO1_PIN) << 1) | digitalRead(JOGWHEEL_OPTO2_PIN);
+  int8_t newState = (digitalRead(_opto1Pin) << 1) | digitalRead(_opto2Pin);
 
   // Determine direction based on the state transition
   if ((_lastState == 0b11 && newState == 0b10) ||

--- a/JogWheel.cpp
+++ b/JogWheel.cpp
@@ -16,7 +16,11 @@ JogWheel::JogWheel(const char position) {
         _opto2Pin = JOGWHEEL_RIGHT_OPTO2_PIN;
     }
 
+<<<<<<< HEAD
     // Initialize instance-level variables.
+=======
+    // Initialize member variables.
+>>>>>>> ee8ceb4 (static stuff)
     _position1 = 0;
     _position2 = 0;
     _activePosition = &_position1;
@@ -29,6 +33,11 @@ void JogWheel::setup() {
   pinMode(_opto2Pin, INPUT);
   _lastState = (digitalRead(_opto1Pin) << 1) | digitalRead(_opto2Pin);
   
+<<<<<<< HEAD
+=======
+  // attachInterrupt(digitalPinToInterrupt(_opto1Pin), updatePosition, CHANGE);
+  // attachInterrupt(digitalPinToInterrupt(_opto2Pin), updatePosition, CHANGE);
+>>>>>>> ee8ceb4 (static stuff)
   if (this == leftInstance) {
       attachInterrupt(digitalPinToInterrupt(_opto1Pin), handleLeftInterrupt, CHANGE);
       attachInterrupt(digitalPinToInterrupt(_opto2Pin), handleLeftInterrupt, CHANGE);

--- a/JogWheel.h
+++ b/JogWheel.h
@@ -11,13 +11,17 @@ constexpr unsigned long MOTION_TIMEOUT = 100;    // milliseconds to wait before 
 
 class JogWheel : public ConsoleWidget {
 public:
-  JogWheel();
+  JogWheel(string position);
   void setup() override;
   void CheckDataSendHID() override;
   void UpdateAnimationFrame() override;
 
 private:
   int32_t readPositionDelta();
+
+  // Initialized differently for left and right jogwheels.
+  int _opto1Pin;
+  int _opto2Pin;
 
   static volatile int32_t _position1;      // First position buffer
   static volatile int32_t _position2;      // Second position buffer

--- a/JogWheel.h
+++ b/JogWheel.h
@@ -19,8 +19,12 @@ public:
 private:
   int32_t readPositionDelta();
 
+  // Static instances of the jogwheel for each direction.
+  // Used in the static interrupt handlers.
   static JogWheel *leftInstance, *rightInstance;
 
+  // attachInterrupt demands static functions, but we want separate instances for each direction.
+  // Therefore, declare the interrupt handlers as static functions.
   static void handleLeftInterrupt() {
       if (leftInstance) leftInstance->updatePosition();
   }

--- a/JogWheel.h
+++ b/JogWheel.h
@@ -11,7 +11,7 @@ constexpr unsigned long MOTION_TIMEOUT = 100;    // milliseconds to wait before 
 
 class JogWheel : public ConsoleWidget {
 public:
-  JogWheel(string position);
+  JogWheel(const char position);
   void setup() override;
   void CheckDataSendHID() override;
   void UpdateAnimationFrame() override;
@@ -19,19 +19,29 @@ public:
 private:
   int32_t readPositionDelta();
 
+  static JogWheel *leftInstance, *rightInstance;
+
+  static void handleLeftInterrupt() {
+      if (leftInstance) leftInstance->updatePosition();
+  }
+
+  static void handleRightInterrupt() {
+      if (rightInstance) rightInstance->updatePosition();
+  }
+
   // Initialized differently for left and right jogwheels.
   int _opto1Pin;
   int _opto2Pin;
 
-  static volatile int32_t _position1;      // First position buffer
-  static volatile int32_t _position2;      // Second position buffer
-  static volatile int32_t* _activePosition;    // Pointer to the currently active position buffer
-  static volatile int32_t* _inactivePosition;  // Pointer to the inactive position buffer
+  volatile int32_t _position1;      // First position buffer
+  volatile int32_t _position2;      // Second position buffer
+  volatile int32_t* _activePosition;    // Pointer to the currently active position buffer
+  volatile int32_t* _inactivePosition;  // Pointer to the inactive position buffer
 
-  static volatile int8_t _lastState;  // Last state of the encoder
+  volatile int8_t _lastState;  // Last state of the encoder
 
   // Update the position based on encoder state
-  static void updatePosition();
+  void updatePosition();
 };
 
 #endif

--- a/control_console_widget_controller.ino
+++ b/control_console_widget_controller.ino
@@ -24,17 +24,10 @@ Trellis led_trellis;
 ConsoleWidget* widgetsA[] = { &neatButton, &redJoystick, &led_trellis };
 
 PowerButtons powerButtons;
-<<<<<<< HEAD
 Faders faders(state);
 JogWheel jogWheelLeft('L');
 JogWheel jogWheelRight('R');
 LEDGrid ledGrid(state);
-=======
-Faders faders;
-JogWheel jogWheelLeft('L');
-JogWheel jogWheelRight('R');
-LEDGrid ledGrid;
->>>>>>> 004423b (static stuff)
 ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheelLeft, &jogWheelRight, &ledGrid };
 
 TriangleButtons triangleButtons;

--- a/control_console_widget_controller.ino
+++ b/control_console_widget_controller.ino
@@ -24,17 +24,10 @@ Trellis led_trellis;
 ConsoleWidget* widgetsA[] = { &neatButton, &redJoystick, &led_trellis };
 
 PowerButtons powerButtons;
-<<<<<<< HEAD
 Faders faders(state);
-JogWheel jogWheelLeft("left");
-JogWheel jogWheelRight("right");
-LEDGrid ledGrid(state);
-=======
-Faders faders;
 JogWheel jogWheelLeft('L');
 JogWheel jogWheelRight('R');
-LEDGrid ledGrid;
->>>>>>> 004423b (static stuff)
+LEDGrid ledGrid(state);
 ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheelLeft, &jogWheelRight, &ledGrid };
 
 TriangleButtons triangleButtons;

--- a/control_console_widget_controller.ino
+++ b/control_console_widget_controller.ino
@@ -24,10 +24,17 @@ Trellis led_trellis;
 ConsoleWidget* widgetsA[] = { &neatButton, &redJoystick, &led_trellis };
 
 PowerButtons powerButtons;
+<<<<<<< HEAD
 Faders faders(state);
 JogWheel jogWheelLeft("left");
 JogWheel jogWheelRight("right");
 LEDGrid ledGrid(state);
+=======
+Faders faders;
+JogWheel jogWheelLeft('L');
+JogWheel jogWheelRight('R');
+LEDGrid ledGrid;
+>>>>>>> 004423b (static stuff)
 ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheelLeft, &jogWheelRight, &ledGrid };
 
 TriangleButtons triangleButtons;

--- a/control_console_widget_controller.ino
+++ b/control_console_widget_controller.ino
@@ -24,10 +24,17 @@ Trellis led_trellis;
 ConsoleWidget* widgetsA[] = { &neatButton, &redJoystick, &led_trellis };
 
 PowerButtons powerButtons;
+<<<<<<< HEAD
 Faders faders(state);
 JogWheel jogWheelLeft('L');
 JogWheel jogWheelRight('R');
 LEDGrid ledGrid(state);
+=======
+Faders faders;
+JogWheel jogWheelLeft('L');
+JogWheel jogWheelRight('R');
+LEDGrid ledGrid;
+>>>>>>> 004423b (static stuff)
 ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheelLeft, &jogWheelRight, &ledGrid };
 
 TriangleButtons triangleButtons;

--- a/control_console_widget_controller.ino
+++ b/control_console_widget_controller.ino
@@ -25,9 +25,10 @@ ConsoleWidget* widgetsA[] = { &neatButton, &redJoystick, &led_trellis };
 
 PowerButtons powerButtons;
 Faders faders(state);
-JogWheel jogWheel;
+JogWheel jogWheelLeft("left");
+JogWheel jogWheelRight("right");
 LEDGrid ledGrid(state);
-ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheel, &ledGrid };
+ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheelLeft, &jogWheelRight, &ledGrid };
 
 TriangleButtons triangleButtons;
 ConsoleWidget* widgetsC[] = { &neatButton, &triangleButtons };

--- a/pins.h
+++ b/pins.h
@@ -44,9 +44,13 @@ constexpr int FADER8_PIN = 21;
 // LEDGrid
 constexpr int LED_GRID_PIN = 22;
 
-// Jogwheel
-constexpr int JOGWHEEL_OPTO1_PIN = 34;  // First optocoupler output
-constexpr int JOGWHEEL_OPTO2_PIN = 35;  // Second optocoupler output
+// Jogwheel 1
+constexpr int JOGWHEEL_LEFT_OPTO1_PIN = 34;  // First optocoupler output
+constexpr int JOGWHEEL_LEFT_OPTO2_PIN = 35;  // Second optocoupler output
+
+// Jogwheel 2
+constexpr int JOGWHEEL_RIGHT_OPTO1_PIN = 36;  // First optocoupler output
+constexpr int JOGWHEEL_RIGHT_OPTO2_PIN = 37;  // Second optocoupler output
 
 /*********** Controller C *******************/
 


### PR DESCRIPTION
Pushed the static-ness into separate interrupt handlers: `handleLeftInterrupt` / `handleRightInterrupt`

All state variables are now instance-level, as well as `updatePosition`. 

`Jogwheel` constructor now takes a char specifying L / R. 

Hopefully this looks reasonable!