### PR TITLE
Add code for knobs

### DIFF
--- a/Knobs.cpp
+++ b/Knobs.cpp
@@ -1,0 +1,30 @@
+#include <Arduino.h>
+#include "Knobs.h"
+#include "pins.h"
+
+Knobs::Knobs() {
+}
+
+void Knobs::setup() {
+    Serial.printf("Knobs setup\n");
+    for (int i = 0; i < KNOBS_COUNT; ++i) {
+        pinMode(_knobPins[i], INPUT);
+    }
+}
+
+void Knobs::CheckDataSendHID() {
+    for (int i = KNOBS_COUNT; i < 1; ++i) {
+    int knob_value = analogRead(_knobPins[i]);
+
+    int previous_knob_value = _knobValues[i];
+    
+    if (abs(knob_value - previous_knob_value) >= 10) {
+      _knobValues[i] = knob_value;
+      Serial.printf("Configuring an axis with value %d for knob %d\n", _knobValues[i], i);
+      (Joystick.*knob_changed_callbacks[i])(_knobValues[i]);
+    }
+  }
+}
+
+void Knobs::UpdateAnimationFrame() {
+}

--- a/Knobs.h
+++ b/Knobs.h
@@ -1,0 +1,34 @@
+#ifndef KNOBS_H
+#define KNOBS_H
+
+#include "ConsoleWidget.h"
+#include "pins.h"
+
+constexpr int KNOBS_COUNT = 4;
+
+class Knobs : public ConsoleWidget {
+public:
+  Knobs();
+  void setup() override;
+  void CheckDataSendHID() override;
+  void UpdateAnimationFrame() override;
+
+private:
+    int _knobPins[KNOBS_COUNT] = { 
+        KNOB1_PIN,
+        KNOB2_PIN,
+        KNOB3_PIN,
+        KNOB4_PIN,
+    };
+
+    void (usb_joystick_class::*knob_changed_callbacks[KNOBS_COUNT])(unsigned int) = {
+        &usb_joystick_class::X,
+        &usb_joystick_class::Y,
+        &usb_joystick_class::Z,
+        &usb_joystick_class::Zrotate,
+    };
+
+    int _knobValues[KNOBS_COUNT] = {0, 0, 0, 0};
+};
+
+#endif

--- a/control_console_widget_controller.ino
+++ b/control_console_widget_controller.ino
@@ -9,6 +9,7 @@
 #include "Trellis.h"
 #include "TriangleButtons.h"
 #include "BigButton.h"
+#include "Knobs.h"
 
 #define ARRAY_LENGTH(array) (sizeof((array)) / sizeof((array)[0]))
 #define LOOP_DELAY_MS 2
@@ -30,10 +31,11 @@ JogWheel jogWheelLeft('L');
 JogWheel jogWheelRight('R');
 LEDGrid ledGrid(state);
 BigButton bigButton;
-ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheelLeft, &jogWheelRight, &ledGrid, &bigButton };
+ConsoleWidget* widgetsB[] = { &neatButton, &powerButtons, &faders, &jogWheelLeft, &jogWheelRight, &ledGrid, &bigButton};
 
 TriangleButtons triangleButtons;
-ConsoleWidget* widgetsC[] = { &neatButton, &triangleButtons };
+Knobs knobs;
+ConsoleWidget* widgetsC[] = { &neatButton, &triangleButtons, &knobs };
 
 ConsoleWidget** widgets = nullptr;
 int numWidgets = 0;

--- a/pins.h
+++ b/pins.h
@@ -57,7 +57,7 @@ constexpr int JOGWHEEL_RIGHT_OPTO2_PIN = 37;  // Second optocoupler output
 
 /*********** Controller C *******************/
 
-// PowerButtons
+// Triangle Buttons
 constexpr int TRIANGLE_BUTTONS_BUTTON1_PIN = 1;
 constexpr int TRIANGLE_BUTTONS_BUTTON2_PIN = 2;
 constexpr int TRIANGLE_BUTTONS_BUTTON3_PIN = 3;
@@ -70,5 +70,11 @@ constexpr int TRIANGLE_BUTTONS_LED3_PIN = 9;
 constexpr int TRIANGLE_BUTTONS_LED4_PIN = 10;
 constexpr int TRIANGLE_BUTTONS_LED5_PIN = 11;
 constexpr int TRIANGLE_BUTTONS_LED6_PIN = 17;
+
+// Knobs (on controller C because it has extra joystick axis outputs)
+constexpr int KNOB1_PIN = 20;
+constexpr int KNOB2_PIN = 21;
+constexpr int KNOB3_PIN = 22;
+constexpr int KNOB4_PIN = 23;
 
 #endif


### PR DESCRIPTION
The knobs have been shifted from controller B to controller C (20-23), updated in sheets as well.

This is because controller B is already using all 6 continuous axis controls for the first 6 faders.

The wiring will therefore need to cross from the middle section to the right section.